### PR TITLE
VA-1005 Fix export-area overflow

### DIFF
--- a/src/scripts/export-page.js
+++ b/src/scripts/export-page.js
@@ -121,8 +121,6 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
       });
 
       self.$exportableBody.prepend(self.$successDiv);
-
-      self.$exportableBody.addClass('joubel-has-success');
     });
   };
 
@@ -372,7 +370,7 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
 
   /**
    * Strips a string of html tags, but keeps the expected whitespace etc.
-   * 
+   *
    * @param {String} html String with html tags
    * @returns {String} string without html tags
    */

--- a/src/styles/document-export-page.css
+++ b/src/styles/document-export-page.css
@@ -105,10 +105,8 @@
   padding-bottom: var(--h5p-theme-spacing-l);
   width: 100%;
   height: calc(100% - 7.5em);
-}
-
-.joubel-exportable-body.joubel-has-success {
-  height: calc(100% - 10em);
+  display: flex;
+  flex-direction: column;
 }
 
 /* ----------------------------- header elements ---------------------------- */
@@ -200,8 +198,6 @@
   overflow: auto;
   box-sizing: border-box;
   max-width: 800px;
-  position: absolute;
-  height: calc(100% - 7.5em);
   width: calc(100% - calc(2*var(--h5p-theme-spacing-s)));
 }
 


### PR DESCRIPTION
When merged in, the exportable-text area will not overflow its container when the submit success message is shown.