### PR TITLE
VA-1348 documentation tool small screen issue

### DIFF
--- a/src/scripts/export-page.js
+++ b/src/scripts/export-page.js
@@ -113,7 +113,7 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
     this.$exportableBody = this.$inner.find('.joubel-exportable-body');
     this.$submitButton = this.$inner.find('.joubel-exportable-submit-button');
     this.$exportButton = this.$inner.find('.joubel-exportable-export-button');
-    this.$exportCloseButton = this.$inner.find('.joubel-export-page-close');
+    this.$exportCloseButton = this.$inner.find('.joubel-exportable-page-close');
     this.$exportCopyButton = this.$inner.find('.joubel-exportable-copy-button');
 
     // Replace newlines with html line breaks
@@ -224,23 +224,29 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
    * Responsive resize function
    */
   ExportPage.prototype.resize = function () {
-    var self = this;
-    var $innerTmp = self.$inner.clone()
+    const self = this;
+    let $innerTmp = self.$inner.clone()
       .css('position', 'absolute')
       .removeClass('responsive')
       .removeClass('no-title')
       .appendTo(self.$inner.parent());
 
-    // Determine if view should be responsive
-    var $headerInner = $('.joubel-exportable-header-inner', $innerTmp);
-    var leftMargin = parseInt($('.joubel-exportable-header-text', $headerInner).css('font-size'), 10);
-    var rightMargin = parseInt($('.joubel-export-page-close', $headerInner).css('font-size'), 10);
+      $innerTmp.find('.header-buttons button').removeClass('icon-only');
 
-    var dynamicRemoveLabelsThreshold = this.calculateHeaderThreshold($innerTmp, (leftMargin + rightMargin));
-    var headerWidth = $headerInner.width();
+    // Determine if view should be responsive
+    const $headerInner = $('.joubel-exportable-header-inner', $innerTmp);
+    const leftMargin = parseInt($('.joubel-exportable-header-text', $headerInner).css('font-size'), 10);
+    const rightMargin = parseInt($('.joubel-exportable-page-close', $headerInner).css('font-size'), 10);
+
+    const dynamicRemoveLabelsThreshold = this.calculateHeaderThreshold($innerTmp, (leftMargin + rightMargin));
+    let headerWidth = $headerInner.width();
 
     if (headerWidth <= dynamicRemoveLabelsThreshold) {
       self.$inner.addClass('responsive');
+
+      self.$inner.find('.header-buttons button').addClass('icon-only');
+      $innerTmp.find('.header-buttons button').addClass('icon-only');
+
       $innerTmp.addClass('responsive');
 
       if (self.$successDiv) {
@@ -249,6 +255,7 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
     }
     else {
       self.$inner.removeClass('responsive');
+      self.$inner.find('.header-buttons button').removeClass('icon-only');
       $innerTmp.remove();
 
       if (self.$successDiv) {
@@ -257,10 +264,9 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
       return;
     }
 
-
     // Determine if view should have no title
     headerWidth = $headerInner.width();
-    var dynamicRemoveTitleThreshold = this.calculateHeaderThreshold($innerTmp, (leftMargin + rightMargin));
+    const dynamicRemoveTitleThreshold = this.calculateHeaderThreshold($innerTmp, (leftMargin + rightMargin));
 
     if (headerWidth <= dynamicRemoveTitleThreshold) {
       self.$inner.addClass('no-title');
@@ -276,24 +282,24 @@ H5P.DocumentExportPage.ExportPage = (function ($, EventDispatcher) {
    * Calculates width of header elements
    */
   ExportPage.prototype.calculateHeaderThreshold = function ($container, margin) {
-    var staticPadding = 1;
+    const staticPadding = 1;
 
     if (margin === undefined || isNaN(margin)) {
       margin = 0;
     }
 
     // Calculate elements width
-    var $submitButtonTmp = $('.joubel-exportable-submit-button', $container);
-    var $exportButtonTmp = $('.joubel-exportable-export-button', $container);
-    var $selectTextButtonTmp = $('.joubel-exportable-copy-button', $container);
-    var $removeDialogButtonTmp = $('.joubel-export-page-close', $container);
-    var $titleTmp = $('.joubel-exportable-header-text', $container);
+    const $submitButtonTmp = $('.joubel-exportable-submit-button', $container);
+    const $exportButtonTmp = $('.joubel-exportable-export-button', $container);
+    const $selectTextButtonTmp = $('.joubel-exportable-copy-button', $container);
+    const $removeDialogButtonTmp = $('.joubel-exportable-page-close', $container);
+    const $titleTmp = $('.joubel-exportable-header-text', $container);
 
     let buttonWidth = $submitButtonTmp.length ? $submitButtonTmp.outerWidth() : 0;
     buttonWidth += $selectTextButtonTmp.length ? $selectTextButtonTmp.outerWidth() : 0;
     buttonWidth += $exportButtonTmp.length ? $exportButtonTmp.outerWidth() : 0;
 
-    var dynamicThreshold = buttonWidth +
+    const dynamicThreshold = buttonWidth +
       $removeDialogButtonTmp.outerWidth() +
       $titleTmp.outerWidth();
 

--- a/src/styles/document-export-page.css
+++ b/src/styles/document-export-page.css
@@ -80,7 +80,7 @@
 /* ------------------------------- main elements ---------------------------- */
 
 .joubel-exportable-header {
-  height: var(--header-height);
+  min-height: var(--header-height);
   color: var(--h5p-theme-text-primary);
   background-color: var(--h5p-theme-ui-base);
   border-bottom: var(--header-bottom-width) solid var(--h5p-theme-stroke-1);

--- a/src/styles/document-export-page.css
+++ b/src/styles/document-export-page.css
@@ -95,10 +95,9 @@
 .joubel-exportable-header-inner {
   height: 100%;
   display: flex;
-  flex-flow: column wrap;
-  align-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
 }
 
 .h5p-column-content .joubel-exportable-header-inner {
@@ -129,6 +128,7 @@
 /* Buttons */
 .joubel-create-document .header-buttons {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--h5p-theme-spacing-xxs);
 }
 

--- a/src/styles/document-export-page.css
+++ b/src/styles/document-export-page.css
@@ -120,7 +120,6 @@
 /* ----------------------------- header elements ---------------------------- */
 
 .joubel-exportable-header-text {
-  float: left;
   margin-left: var(--h5p-theme-spacing-s);
   line-height: calc(var(--h5p-theme-font-size-xl)*2);
   font-size: var(--h5p-theme-font-size-xl);
@@ -130,7 +129,6 @@
 /* Buttons */
 .joubel-create-document .header-buttons {
   display: flex;
-  flex-flow: row;
   gap: var(--h5p-theme-spacing-xxs);
 }
 
@@ -146,7 +144,6 @@
   color: var(--h5p-theme-text-third);
   background-color: var(--h5p-theme-ui-base);
   box-shadow: 0 0 5px 1px var(--h5p-theme-alternative-darker);
-
   overflow: auto;
   box-sizing: border-box;
   max-width: 800px;
@@ -154,10 +151,7 @@
 }
 
 .joubel-exportable-success-message {
-  margin-top: 0;
-  margin-right: var(--h5p-theme-spacing-s);
-  margin-bottom: var(--h5p-theme-spacing-s);
-  margin-left: var(--h5p-theme-spacing-s);
+  margin: 0 var(--h5p-theme-spacing-s) var(--h5p-theme-spacing-s);
   text-align: center;
   background: var(--h5p-theme-feedback-correct-secondary);
   padding: calc(var(--h5p-theme-spacing-s)*0.6);
@@ -176,10 +170,7 @@
 }
 
 .joubel-create-document.responsive .joubel-exportable-area {
-  -webkit-box-shadow: none;
-  -moz-box-shadow: none;
   box-shadow: none;
-
   margin: 0;
   width: 100%;
 }

--- a/src/styles/document-export-page.css
+++ b/src/styles/document-export-page.css
@@ -80,7 +80,6 @@
 /* ------------------------------- main elements ---------------------------- */
 
 .joubel-exportable-header {
-  min-height: var(--header-height);
   color: var(--h5p-theme-text-primary);
   background-color: var(--h5p-theme-ui-base);
   border-bottom: var(--header-bottom-width) solid var(--h5p-theme-stroke-1);
@@ -93,7 +92,7 @@
 }
 
 .joubel-exportable-header-inner {
-  height: 100%;
+  min-height: var(--header-height);
   display: flex;
   flex-wrap: wrap;
   align-items: center;


### PR DESCRIPTION
## 🗒️ Note to reviewer
- https://github.com/h5p/h5p-document-export-page/pull/74/commits/0f0e7ae297d891ed9f805c2beffd38d587b863ff The first commit solves this issue "_**On small screens, the “Document your project!” text is hidden, and only the submit, download, edit, and close icons are visible - just like production**_."

**Note:** to solve this issue properly I also needed to make some changes to button-component. The PR is here. https://github.com/h5p/h5p-components/pull/88 
It solves the buttons height mismatch issue, 
<img width="814" height="193" alt="image" src="https://github.com/user-attachments/assets/d9dc17a4-d19a-4f2f-848d-49443b84e822" />

